### PR TITLE
Enforce five-card plays and show blind score

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,3 +48,7 @@
 - [ ] Write unit tests. (Skipped due to pytest installation issues)
 - [x] Add comprehensive documentation.
 - [x] Fix: Game not progressing when cards are played.
+- [x] Only allow player to play 5 cards.
+- [x] Show score needed to win blind.
+- [x] Fix: Two Pair registered only as a Pair.
+- [x] Display play again option if player loses.

--- a/balatro/cli.py
+++ b/balatro/cli.py
@@ -81,12 +81,23 @@ class BalatroCLI:
     def run(self) -> Game:
         """Start the interactive command loop."""
         self._print_help()
-        while not self.game.game_over:
-            print(self.game)
-            user_input = input("Enter your action: ").strip().lower()
-            action = user_input[:1]
-            additional_input = user_input[1:]
-            if not self._handle_action(action, additional_input):
+        while True:
+            while not self.game.game_over:
+                print(self.game)
+                user_input = input("Enter your action: ").strip().lower()
+                action = user_input[:1]
+                additional_input = user_input[1:]
+                if not self._handle_action(action, additional_input):
+                    return self.game
+            again = input("Play again? (y/n): ").strip().lower()
+            if again == "y":
+                deck_type = self.game.deck_key
+                self.game = Game(deck_type=deck_type)
+                print(f"You have chosen the {self.game.deck.name}!")
+                self.game.draw_hand()
+                self.game.game_over = False
+                self._print_help()
+            else:
                 break
         return self.game
 

--- a/balatro/core/game.py
+++ b/balatro/core/game.py
@@ -173,6 +173,9 @@ class Game:
         self.player.use_planet_card(index, self)
 
     def play_hand(self, cards_to_play: list[Card]):
+        if len(cards_to_play) != 5:
+            print("Error: You must play exactly 5 cards.")
+            return
         if not all(c in self.player.hand for c in cards_to_play):
             print("Error: One or more cards are not in the current hand.")
             return
@@ -245,6 +248,7 @@ class Game:
             "--------------------",
             repr(self),
             f"Current Ante: {self.ante}",
+            f"Score needed to win blind: {self.blind_manager.current.score_required}",
         ]
 
         lines += render_section(

--- a/balatro/core/poker.py
+++ b/balatro/core/poker.py
@@ -65,7 +65,7 @@ def evaluate_hand(cards: list[Card]) -> PokerHand | None:
     is_four_of_a_kind = counts[0] == 4
     is_full_house = counts == [3, 2]
     is_three_of_a_kind = counts[0] == 3
-    is_two_pair = counts == [2, 2, 1]
+    is_two_pair = list(rank_counts.values()).count(2) == 2
     is_pair = counts[0] == 2
 
     # --- Determine the hand based on checks ---


### PR DESCRIPTION
## Summary
- limit card plays to exactly five cards and display target score for current blind
- fix two-pair evaluation and add replay prompt after losses
- document recent fixes in TODO

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py <<'EOF'
p 0 1 2 3
q
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68aa2f9fc5448332a28ba1515bf72b08