### PR TITLE
Enable gameplay modifiers from JSON data

### DIFF
--- a/balatro/cards/planet_cards.py
+++ b/balatro/cards/planet_cards.py
@@ -65,10 +65,13 @@ def load_planet_cards():
 
     cards = []
     for entry in raw:
-        addition = entry.get("addition", "")
-        match = re.search(r"\+(\d+)\s*Mult.*\+(\d+)\s*Chips", addition)
-        mult = int(match.group(1)) if match else 0
-        chips = int(match.group(2)) if match else 0
+        mult = int(entry.get("mult_bonus", 0))
+        chips = int(entry.get("chips_bonus", 0))
+        if not mult and not chips:
+            addition = entry.get("addition", "")
+            match = re.search(r"\+(\d+)\s*Mult.*\+(\d+)\s*Chips", addition)
+            mult = int(match.group(1)) if match else 0
+            chips = int(match.group(2)) if match else 0
         card = PlanetCard(
             name=entry["name"],
             chips_bonus=chips,

--- a/balatro/core/scoring.py
+++ b/balatro/core/scoring.py
@@ -88,6 +88,8 @@ def calculate_score(
             print(f"Gold Seal card played: +$3. Current money: ${game.money}")
 
     for joker in jokers:
+        if not joker.applies_to(hand_type):
+            continue
         new_chips = joker.apply_chips(chips)
         if new_chips != chips:
             messages.append(f"{joker.name} changes chips {chips} -> {new_chips}")
@@ -96,6 +98,9 @@ def calculate_score(
         if new_mult != mult:
             messages.append(f"{joker.name} changes mult {mult} -> {new_mult}")
         mult = new_mult
+        if joker.retrigger:
+            mult *= 1 + joker.retrigger
+            messages.append(f"{joker.name} retriggers: x{1 + joker.retrigger} mult")
 
     final_score = chips * mult
     messages.append(f"Final: {chips} chips x {mult} mult = {final_score}")

--- a/data/jokers.json
+++ b/data/jokers.json
@@ -7,7 +7,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 4
   },
   {
     "number": 2,
@@ -17,7 +19,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 3,
@@ -27,7 +31,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 4,
@@ -37,7 +43,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 5,
@@ -47,7 +55,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 6,
@@ -57,7 +67,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 8,
+    "hand": "PAIR"
   },
   {
     "number": 7,
@@ -67,7 +80,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 12,
+    "hand": "THREE_OF_A_KIND"
   },
   {
     "number": 8,
@@ -77,7 +93,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 10,
+    "hand": "TWO_PAIR"
   },
   {
     "number": 9,
@@ -87,7 +106,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 12,
+    "hand": "STRAIGHT"
   },
   {
     "number": 10,
@@ -97,7 +119,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 10,
+    "hand": "FLUSH"
   },
   {
     "number": 11,
@@ -107,7 +132,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 50,
+    "mult": 0,
+    "hand": "PAIR"
   },
   {
     "number": 12,
@@ -117,7 +145,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 100,
+    "mult": 0,
+    "hand": "THREE_OF_A_KIND"
   },
   {
     "number": 13,
@@ -127,7 +158,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 80,
+    "mult": 0,
+    "hand": "TWO_PAIR"
   },
   {
     "number": 14,
@@ -137,7 +171,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 100,
+    "mult": 0,
+    "hand": "STRAIGHT"
   },
   {
     "number": 15,
@@ -147,7 +184,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 80,
+    "mult": 0,
+    "hand": "FLUSH"
   },
   {
     "number": 16,
@@ -157,7 +197,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 20
   },
   {
     "number": 17,
@@ -167,7 +209,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 18,
@@ -177,7 +221,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 19,
@@ -187,7 +233,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "...",
-    "activation": "On Held"
+    "activation": "On Held",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 1
   },
   {
     "number": 20,
@@ -197,7 +246,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 21,
@@ -207,7 +258,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 22,
@@ -217,7 +270,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 30,
+    "mult": 0
   },
   {
     "number": 23,
@@ -227,7 +282,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 15
   },
   {
     "number": 24,
@@ -237,7 +294,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 25,
@@ -247,7 +306,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 4.0
   },
   {
     "number": 26,
@@ -257,7 +319,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 27,
@@ -267,7 +331,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 28,
@@ -277,7 +343,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "...",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 1
   },
   {
     "number": 29,
@@ -287,7 +356,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Held"
+    "activation": "On Held",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 30,
@@ -297,7 +368,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 31,
@@ -307,7 +380,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 8
   },
   {
     "number": 32,
@@ -317,7 +392,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start. (Can only appear in the shop when there is a Steel Card in the deck.)",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.2
   },
   {
     "number": 33,
@@ -327,7 +405,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 30,
+    "mult": 0
   },
   {
     "number": 34,
@@ -337,7 +417,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 35,
@@ -347,7 +429,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 36,
@@ -357,7 +441,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "...",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 1
   },
   {
     "number": 37,
@@ -367,7 +454,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 38,
@@ -377,7 +466,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 15
   },
   {
     "number": 39,
@@ -387,7 +478,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 4
   },
   {
     "number": 40,
@@ -397,7 +490,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 31,
+    "mult": 0
   },
   {
     "number": 41,
@@ -407,7 +502,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "++",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 20,
+    "mult": 4
   },
   {
     "number": 42,
@@ -417,7 +514,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 43,
@@ -427,7 +526,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 44,
@@ -437,7 +538,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 1
   },
   {
     "number": 45,
@@ -447,7 +550,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "On Played"
+    "activation": "On Played",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 46,
@@ -457,7 +562,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 47,
@@ -467,7 +574,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 48,
@@ -477,7 +586,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 49,
@@ -487,7 +599,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 15,
+    "mult": 0,
+    "hand": "STRAIGHT"
   },
   {
     "number": 50,
@@ -497,7 +612,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 100,
+    "mult": 0
   },
   {
     "number": 51,
@@ -507,7 +624,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "On Played"
+    "activation": "On Played",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 52,
@@ -517,7 +636,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 53,
@@ -527,7 +648,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 2,
+    "mult": 0
   },
   {
     "number": 54,
@@ -537,7 +660,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 55,
@@ -547,7 +672,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.1
   },
   {
     "number": 56,
@@ -557,7 +685,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 5,
+    "mult": 0
   },
   {
     "number": 57,
@@ -567,7 +697,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Discard"
+    "activation": "On Discard",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 58,
@@ -577,7 +709,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 1
   },
   {
     "number": 59,
@@ -587,7 +721,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 60,
@@ -597,7 +733,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Played"
+    "activation": "On Played",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 61,
@@ -607,7 +745,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start. (Can only appear in the shop when Gros Michel has destroyed itself in the current run.)",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 62,
@@ -617,7 +758,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 63,
@@ -627,7 +771,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 3
   },
   {
     "number": 64,
@@ -637,7 +783,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.5
   },
   {
     "number": 65,
@@ -647,7 +796,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 4,
+    "mult": 0
   },
   {
     "number": 66,
@@ -657,7 +808,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 67,
@@ -667,7 +820,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 68,
@@ -677,7 +832,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.1
   },
   {
     "number": 69,
@@ -687,7 +845,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 70,
@@ -697,7 +857,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.25
   },
   {
     "number": 71,
@@ -707,7 +870,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 72,
@@ -717,7 +882,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "On Held"
+    "activation": "On Held",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 1.5
   },
   {
     "number": 73,
@@ -727,7 +895,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 74,
@@ -737,7 +907,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 75,
@@ -747,7 +919,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.2
   },
   {
     "number": 76,
@@ -757,7 +932,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "On Played"
+    "activation": "On Played",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 77,
@@ -767,7 +944,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 78,
@@ -777,7 +956,10 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0
   },
   {
     "number": 79,
@@ -787,7 +969,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 80,
@@ -797,7 +981,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 81,
@@ -807,7 +993,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 4
   },
   {
     "number": 82,
@@ -817,7 +1005,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Held"
+    "activation": "On Held",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 83,
@@ -827,7 +1017,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Discard"
+    "activation": "On Discard",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 84,
@@ -837,7 +1029,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 85,
@@ -847,7 +1041,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 86,
@@ -857,7 +1053,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 1
   },
   {
     "number": 87,
@@ -867,7 +1065,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 88,
@@ -877,7 +1077,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 89,
@@ -887,7 +1089,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start. (Can only appear in the shop when there is a Stone Card in the deck.)",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 25,
+    "mult": 0
   },
   {
     "number": 90,
@@ -897,7 +1101,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 91,
@@ -907,7 +1113,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start. (Can only appear in the shop when there is a Lucky Card in the deck.)",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.25
   },
   {
     "number": 92,
@@ -917,7 +1126,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "On Other Jokers"
+    "activation": "On Other Jokers",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 1.5
   },
   {
     "number": 93,
@@ -927,7 +1139,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 2,
+    "mult": 0
   },
   {
     "number": 94,
@@ -937,7 +1151,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 95,
@@ -947,7 +1163,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+$",
-    "activation": "On Discard"
+    "activation": "On Discard",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 96,
@@ -957,7 +1175,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 2
   },
   {
     "number": 97,
@@ -967,7 +1187,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 20
   },
   {
     "number": 98,
@@ -977,7 +1199,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 2,
+    "hand": "TWO_PAIR"
   },
   {
     "number": 99,
@@ -987,7 +1212,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 1.5
   },
   {
     "number": 100,
@@ -997,7 +1225,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0
   },
   {
     "number": 101,
@@ -1007,7 +1238,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "++",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 10,
+    "mult": 4
   },
   {
     "number": 102,
@@ -1017,7 +1250,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "...",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 1
   },
   {
     "number": 103,
@@ -1027,7 +1263,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Available from start.",
     "type": "+c",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 3,
+    "mult": 0
   },
   {
     "number": 104,
@@ -1037,7 +1275,9 @@
     "rarity": "Common",
     "unlock_requirement": "Available from start.",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 5
   },
   {
     "number": 105,
@@ -1047,7 +1287,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Available from start.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.25
   },
   {
     "number": 106,
@@ -1057,7 +1300,9 @@
     "rarity": "Common",
     "unlock_requirement": "Play a 5 card hand that contains only Gold cards. (Can only appear in the shop when there is a Gold Card in the deck.)",
     "type": "+$",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 107,
@@ -1067,7 +1312,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Lose five runs.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 108,
@@ -1077,7 +1324,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Play 200 hands",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 109,
@@ -1087,7 +1337,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Play 300 face cards across all runs.",
     "type": "...",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 1
   },
   {
     "number": 110,
@@ -1097,7 +1350,9 @@
     "rarity": "Common",
     "unlock_requirement": "Sell 20 Jokers.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 1
   },
   {
     "number": 111,
@@ -1107,7 +1362,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Win 5 consecutive rounds by playing only a single hand in each. (Discards are fine.)",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 112,
@@ -1117,7 +1374,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have a Gold card with a Gold Seal .",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 113,
@@ -1127,7 +1386,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have 3 or more Wild Cards in your deck.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 114,
@@ -1137,7 +1398,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Continue a run from the Main Menu.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.25
   },
   {
     "number": 115,
@@ -1147,7 +1411,10 @@
     "rarity": "Common",
     "unlock_requirement": "Beat a Boss Blind with a High Card hand.",
     "type": "...",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "retrigger": 2
   },
   {
     "number": 116,
@@ -1157,7 +1424,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least 30 Diamonds in your deck",
     "type": "+$",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 117,
@@ -1167,7 +1436,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least 30 Hearts in your deck.",
     "type": "Xm",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 1.5
   },
   {
     "number": 118,
@@ -1177,7 +1449,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least 30 Spades in your deck.",
     "type": "+c",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 50,
+    "mult": 0
   },
   {
     "number": 119,
@@ -1187,7 +1461,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least 30 Clubs in your deck",
     "type": "+m",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 7
   },
   {
     "number": 120,
@@ -1197,7 +1473,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have 5 or more Glass cards in your deck. (Can only appear in the shop when there is a Glass Card in the deck.)",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.75
   },
   {
     "number": 121,
@@ -1207,7 +1486,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Reach Ante level 4",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 122,
@@ -1217,7 +1498,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Reach Ante Level 8",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 123,
@@ -1227,7 +1511,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Win 1 run.",
     "type": "!!",
-    "activation": ""
+    "activation": "",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 124,
@@ -1237,7 +1523,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run in 18 or fewer rounds.",
     "type": "+c",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 8,
+    "mult": 0
   },
   {
     "number": 125,
@@ -1247,7 +1535,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Win a run in 12 or fewer rounds",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 126,
@@ -1257,7 +1547,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Earn at least 10,000 Chips in a single hand.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 127,
@@ -1267,7 +1559,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "In one hand, earn at least 1,000,000 Chips.",
     "type": "Xm",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0
   },
   {
     "number": 128,
@@ -1277,7 +1572,10 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Play a hand that contains four 7 of Clubs. Other suits that count as clubs (e.g. wild suits) with rank 7 will also count.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0
   },
   {
     "number": 129,
@@ -1287,7 +1585,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Defeat a Boss Blind in one hand, without using discards.",
     "type": "+$",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 130,
@@ -1297,7 +1597,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Discard 5 Jacks at the same time.",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 0.5
   },
   {
     "number": 131,
@@ -1307,7 +1610,11 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run without playing a Pair .",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0,
+    "hand": "PAIR"
   },
   {
     "number": 132,
@@ -1317,7 +1624,11 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run without playing a Three of a Kind .",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0,
+    "hand": "THREE_OF_A_KIND"
   },
   {
     "number": 133,
@@ -1327,7 +1638,11 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run without playing a Four of a Kind .",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 4.0,
+    "hand": "FOUR_OF_A_KIND"
   },
   {
     "number": 134,
@@ -1337,7 +1652,11 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run without playing a Straight .",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0,
+    "hand": "STRAIGHT"
   },
   {
     "number": 135,
@@ -1347,7 +1666,11 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a run without playing a Flush .",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0,
+    "hand": "FLUSH"
   },
   {
     "number": 136,
@@ -1357,7 +1680,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Earn at least 100 million (100,000,000) Chips in a single hand.",
     "type": "+c",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 250,
+    "mult": 0
   },
   {
     "number": 137,
@@ -1367,7 +1692,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Win a game while never having more than 4 jokers.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 138,
@@ -1377,7 +1704,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Discard a Royal Flush .",
     "type": "!!",
-    "activation": ""
+    "activation": "",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 139,
@@ -1387,7 +1716,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least $400.",
     "type": "+$",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 140,
@@ -1397,7 +1728,9 @@
     "rarity": "Common",
     "unlock_requirement": "Play every Heart card in your deck in one round.",
     "type": "+m",
-    "activation": "On Held"
+    "activation": "On Held",
+    "chips": 0,
+    "mult": 13
   },
   {
     "number": 141,
@@ -1407,7 +1740,10 @@
     "rarity": "Rare",
     "unlock_requirement": "Enhance 16 cards in your deck",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 3.0
   },
   {
     "number": 142,
@@ -1417,7 +1753,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Discover every Tarot Card.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 143,
@@ -1427,7 +1765,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Discover all Planet cards.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 144,
@@ -1437,7 +1777,9 @@
     "rarity": "Rare",
     "unlock_requirement": "Sell 50 cards.",
     "type": "!!",
-    "activation": "On Discard"
+    "activation": "On Discard",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 145,
@@ -1447,7 +1789,9 @@
     "rarity": "Uncommon",
     "unlock_requirement": "Have at least 2 Polychrome Jokers at the same time.",
     "type": "+m",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 2
   },
   {
     "number": 146,
@@ -1457,7 +1801,9 @@
     "rarity": "Legendary",
     "unlock_requirement": "Find this Joker from the Soul card.",
     "type": "Xm",
-    "activation": "Indep."
+    "activation": "Indep.",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 147,
@@ -1467,7 +1813,10 @@
     "rarity": "Legendary",
     "unlock_requirement": "Find this Joker from the Soul card.",
     "type": "Xm",
-    "activation": "On Scored"
+    "activation": "On Scored",
+    "chips": 0,
+    "mult": 0,
+    "mult_multiplier": 2.0
   },
   {
     "number": 148,
@@ -1477,7 +1826,9 @@
     "rarity": "Legendary",
     "unlock_requirement": "Find this Joker from the Soul card.",
     "type": "Xm",
-    "activation": "Mixed"
+    "activation": "Mixed",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 149,
@@ -1487,7 +1838,9 @@
     "rarity": "Legendary",
     "unlock_requirement": "Find this Joker from the Soul card.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   },
   {
     "number": 150,
@@ -1497,6 +1850,8 @@
     "rarity": "Legendary",
     "unlock_requirement": "Find this Joker from the Soul card.",
     "type": "!!",
-    "activation": "N/A"
+    "activation": "N/A",
+    "chips": 0,
+    "mult": 0
   }
 ]

--- a/data/planet_cards.json
+++ b/data/planet_cards.json
@@ -4,83 +4,107 @@
     "addition": "+1 Mult and +10 Chips",
     "poker_hand": "High Card",
     "hand_base_score": "1 Mult x 5 Chips",
-    "type": "Dwarf Planet"
+    "type": "Dwarf Planet",
+    "mult_bonus": 1,
+    "chips_bonus": 10
   },
   {
     "name": "Mercury",
     "addition": "+1 Mult and +15 Chips",
     "poker_hand": "Pair",
     "hand_base_score": "2 Mult x 10 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 1,
+    "chips_bonus": 15
   },
   {
     "name": "Uranus",
     "addition": "+1 Mult and +20 Chips",
     "poker_hand": "Two Pair",
     "hand_base_score": "2 Mult x 20 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 1,
+    "chips_bonus": 20
   },
   {
     "name": "Venus",
     "addition": "+2 Mult and +20 Chips",
     "poker_hand": "Three of a Kind",
     "hand_base_score": "3 Mult x 30 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 2,
+    "chips_bonus": 20
   },
   {
     "name": "Saturn",
     "addition": "+3 Mult and +30 Chips",
     "poker_hand": "Straight",
     "hand_base_score": "4 Mult x 30 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 3,
+    "chips_bonus": 30
   },
   {
     "name": "Jupiter",
     "addition": "+2 Mult and +15 Chips",
     "poker_hand": "Flush",
     "hand_base_score": "4 Mult x 35 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 2,
+    "chips_bonus": 15
   },
   {
     "name": "Earth",
     "addition": "+2 Mult and +25 Chips",
     "poker_hand": "Full House",
     "hand_base_score": "4 Mult x 40 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 2,
+    "chips_bonus": 25
   },
   {
     "name": "Mars",
     "addition": "+3 Mult and +30 Chips",
     "poker_hand": "Four of a Kind",
     "hand_base_score": "7 Mult x 60 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 3,
+    "chips_bonus": 30
   },
   {
     "name": "Neptune",
     "addition": "+4 Mult and +40 Chips",
     "poker_hand": "Straight Flush",
     "hand_base_score": "8 Mult x 100 Chips",
-    "type": "Planet"
+    "type": "Planet",
+    "mult_bonus": 4,
+    "chips_bonus": 40
   },
   {
     "name": "Planet X",
     "addition": "+3 Mult and +35 Chips",
     "poker_hand": "Five of a Kind",
     "hand_base_score": "12 Mult x 120 Chips",
-    "type": "Planet?"
+    "type": "Planet?",
+    "mult_bonus": 3,
+    "chips_bonus": 35
   },
   {
     "name": "Ceres",
     "addition": "+4 Mult and +40 Chips",
     "poker_hand": "Flush House",
     "hand_base_score": "14 Mult x 140 Chips",
-    "type": "Dwarf Planet"
+    "type": "Dwarf Planet",
+    "mult_bonus": 4,
+    "chips_bonus": 40
   },
   {
     "name": "Eris",
     "addition": "+3 Mult and +50 Chips",
     "poker_hand": "Flush Five",
     "hand_base_score": "16 Mult x 160 Chips",
-    "type": "Dwarf Planet"
+    "type": "Dwarf Planet",
+    "mult_bonus": 3,
+    "chips_bonus": 50
   }
 ]


### PR DESCRIPTION
## Summary
- remove hardcoded Joker subclasses and build jokers entirely from JSON
- support hand-specific activation and retrigger counts on Jokers
- record hand and retrigger fields in `jokers.json`

## Testing
- `python -m py_compile balatro/cards/jokers.py balatro/core/scoring.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa597f4b68833281cb2c262ac92b34