### PR TITLE
Implement tarot/spectral card effects and inventory usage commands

### DIFF
--- a/balatro/cards/cards.py
+++ b/balatro/cards/cards.py
@@ -36,6 +36,7 @@ class Enhancement(Enum):
     LUCKY = "Lucky"
     MULT = "Mult"
     CHIP = "Chip"
+    STONE = "Stone"
 
 class Edition(Enum):
     """Represents an edition applied to a playing card."""

--- a/balatro/cards/spectral_cards.py
+++ b/balatro/cards/spectral_cards.py
@@ -3,28 +3,96 @@
 from __future__ import annotations
 
 import json
+import random
 from pathlib import Path
+
+from .cards import Card, Suit, Edition, Seal
 
 
 class SpectralCard:
     """Simple representation of a Spectral card."""
 
-    def __init__(self, name: str, description: str, cost: int = 4) -> None:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        cost: int = 4,
+        targets: int = 0,
+        action: str | None = None,
+        params: dict | None = None,
+    ) -> None:
         self.name = name
         self.description = description
         self.cost = cost
+        self.targets = targets
+        self.action = action
+        self.params = params or {}
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return f"SpectralCard(name='{self.name}')"
 
-    def apply_effect(self, game) -> None:  # pragma: no cover - placeholder
-        """Apply the spectral card's effect.
+    def apply_effect(self, game, chosen: list[Card] | None = None) -> None:
+        """Apply the spectral card's effect."""
 
-        The project does not yet model individual spectral card effects. This
-        placeholder prevents runtime errors when a card is used.
-        """
+        player = game.player
+        cards = chosen or []
+        if not cards and self.targets > 0:
+            print("--- Available Cards for Application ---")
+            for i, c in enumerate(player.hand):
+                print(f"[{i}] {c}")
+            print("---------------------------")
+            selection = input(
+                "Select target indices separated by space: "
+            ).strip()
+            if selection:
+                indices = [int(s) for s in selection.split()][: self.targets]
+                cards = [player.hand[i] for i in indices if 0 <= i < len(player.hand)]
 
-        print(f"{self.name} used: {self.description} (effect not yet implemented).")
+        def _add_random_edition(_, selected, __):
+            if selected:
+                card = selected[0]
+                card.edition = random.choice(
+                    [Edition.FOIL, Edition.HOLOGRAPHIC, Edition.POLYCHROME]
+                )
+                print(f"{card} gained {card.edition.value} edition.")
+
+        def _add_seal(_, selected, params):
+            if selected:
+                card = selected[0]
+                seal = Seal[params.get("seal", "GOLD")]
+                card.seal = seal
+                print(f"{card} gained a {seal.value} Seal.")
+
+        def _convert_all_random_suit(game, _selected, __):
+            suit = random.choice(list(Suit))
+            for c in game.player.hand:
+                c.suit = suit
+            print(f"All cards converted to {suit.value}.")
+
+        def _copy_card(game, selected, params):
+            if selected:
+                card = selected[0]
+                copies = int(params.get("copies", 1))
+                for _ in range(copies):
+                    game.player.hand.append(
+                        Card(card.suit, card.rank, card.enhancement, card.edition, card.seal)
+                    )
+                print(f"Created {copies} copies of selected card.")
+
+        actions = {
+            "add_random_edition": _add_random_edition,
+            "add_seal": _add_seal,
+            "convert_all_random_suit": _convert_all_random_suit,
+            "copy_card": _copy_card,
+        }
+
+        func = actions.get(self.action)
+        if func:
+            func(game, cards, self.params)
+        else:
+            print(f"{self.name} used: {self.description} (effect not yet implemented).")
+
+        game.last_used_card = self
 
     def to_dict(self) -> dict:
         return {
@@ -32,11 +100,21 @@ class SpectralCard:
             "name": self.name,
             "description": self.description,
             "cost": self.cost,
+            "targets": self.targets,
+            "action": self.action,
+            "params": self.params,
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "SpectralCard":
-        return cls(data["name"], data["description"], data.get("cost", 4))
+        return cls(
+            data["name"],
+            data["description"],
+            data.get("cost", 4),
+            data.get("targets", 0),
+            data.get("action"),
+            data.get("params"),
+        )
 
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
@@ -50,10 +128,18 @@ def load_spectral_cards() -> list[SpectralCard]:
 
     cards = []
     for entry in raw:
+        params = {
+            k: v
+            for k, v in entry.items()
+            if k not in {"name", "effect", "targets", "action"}
+        }
         card = SpectralCard(
             name=entry.get("name", ""),
             description=entry.get("effect", ""),
             cost=4,
+            targets=int(entry.get("targets", 0)),
+            action=entry.get("action"),
+            params=params,
         )
         cards.append(card)
 

--- a/balatro/cards/tarot_cards.py
+++ b/balatro/cards/tarot_cards.py
@@ -3,28 +3,156 @@
 from __future__ import annotations
 
 import json
+import random
 from pathlib import Path
+
+from .cards import Card, Suit, Rank, Enhancement, Edition
+from ..cards.jokers import load_jokers
+from ..cards.planet_cards import load_planet_cards
 
 
 class TarotCard:
     """Simple representation of a Tarot card."""
 
-    def __init__(self, name: str, description: str, cost: int = 0) -> None:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        cost: int = 0,
+        targets: int = 0,
+        action: str | None = None,
+        params: dict | None = None,
+    ) -> None:
         self.name = name
         self.description = description
         self.cost = cost
+        self.targets = targets
+        self.action = action
+        self.params = params or {}
 
     def __repr__(self) -> str:  # pragma: no cover - simple repr
         return f"TarotCard(name='{self.name}')"
 
-    def apply_effect(self, game) -> None:  # pragma: no cover - placeholder
-        """Apply the tarot card's effect.
+    def apply_effect(self, game, chosen: list[Card] | None = None) -> None:
+        """Apply the tarot card's effect."""
 
-        The project does not yet model individual tarot card effects. This
-        placeholder prevents runtime errors when a card is used.
-        """
+        player = game.player
+        cards = chosen or []
+        if not cards and self.targets > 0:
+            print("--- Available Cards for Application ---")
+            for i, c in enumerate(player.hand):
+                print(f"[{i}] {c}")
+            print("---------------------------")
+            selection = input(
+                "Select target indices separated by space: "
+            ).strip()
+            if selection:
+                indices = [int(s) for s in selection.split()][: self.targets]
+                cards = [player.hand[i] for i in indices if 0 <= i < len(player.hand)]
 
-        print(f"{self.name} used: {self.description} (effect not yet implemented).")
+        def _apply_enhancement(_game, selected, params):
+            enh = Enhancement[params.get("enhancement", "LUCKY")]
+            for c in selected:
+                c.enhancement = enh
+            print(f"Applied {enh.value} to {len(selected)} card(s).")
+
+        def _convert_suit(_game, selected, params):
+            suit = Suit[params.get("suit", "HEARTS")]
+            for c in selected:
+                c.suit = suit
+            print(f"Converted {len(selected)} card(s) to {suit.value}.")
+
+        def _increase_rank(_game, selected, params):
+            order = [
+                Rank.TWO,
+                Rank.THREE,
+                Rank.FOUR,
+                Rank.FIVE,
+                Rank.SIX,
+                Rank.SEVEN,
+                Rank.EIGHT,
+                Rank.NINE,
+                Rank.TEN,
+                Rank.JACK,
+                Rank.QUEEN,
+                Rank.KING,
+                Rank.ACE,
+            ]
+            for c in selected:
+                idx = order.index(c.rank)
+                c.rank = order[(idx + 1) % len(order)]
+            print(f"Increased rank of {len(selected)} card(s).")
+
+        def _destroy(game, selected, _params):
+            for c in selected:
+                if c in game.player.hand:
+                    game.player.hand.remove(c)
+            print(f"Destroyed {len(selected)} card(s).")
+
+        def _transform(game, selected, _params):
+            if len(selected) >= 2:
+                src, dst = selected[0], selected[1]
+                dst.suit = src.suit
+                dst.rank = src.rank
+                dst.enhancement = src.enhancement
+                dst.edition = src.edition
+                dst.seal = src.seal
+                if src in game.player.hand:
+                    game.player.hand.remove(src)
+                print("Converted second card into first card and destroyed the original.")
+
+        def _double_money(game, _selected, _params):
+            game.player.money = min(game.player.money * 2, 20)
+            print(f"Money is now ${game.player.money}.")
+
+        def _add_planet_cards(game, _selected, params):
+            count = int(params.get("count", 2))
+            new_cards = random.sample(load_planet_cards(), k=count)
+            game.player.planet_cards.extend(new_cards)
+            print(f"Gained {count} Planet card(s).")
+
+        def _add_tarot_cards(game, _selected, params):
+            count = int(params.get("count", 2))
+            new_cards = random.sample(load_tarot_cards(), k=count)
+            game.player.tarot_cards.extend(new_cards)
+            print(f"Gained {count} Tarot card(s).")
+
+        def _wheel_of_fortune(game, _selected, params):
+            chance = float(params.get("chance", 0.25))
+            if game.player.jokers and random.random() < chance:
+                joker = random.choice(game.player.jokers)
+                joker.edition = random.choice(
+                    [Edition.FOIL, Edition.HOLOGRAPHIC, Edition.POLYCHROME]
+                )
+                print(f"{joker.name} gained {joker.edition.value} edition.")
+            else:
+                print("Wheel of Fortune had no effect.")
+
+        def _add_random_joker(game, _selected, _params):
+            joker = random.choice(load_jokers())
+            game.player.jokers.append(joker)
+            print(f"Gained Joker {joker.name}.")
+
+        actions = {
+            "apply_enhancement": _apply_enhancement,
+            "convert_suit": _convert_suit,
+            "increase_rank": _increase_rank,
+            "destroy": _destroy,
+            "transform": _transform,
+            "double_money": _double_money,
+            "add_planet_cards": _add_planet_cards,
+            "add_tarot_cards": _add_tarot_cards,
+            "wheel_of_fortune": _wheel_of_fortune,
+            "add_random_joker": _add_random_joker,
+        }
+
+        func = actions.get(self.action)
+        if func:
+            func(game, cards, self.params)
+        else:
+            print(f"{self.name} used: {self.description} (effect not yet implemented).")
+
+        game.last_used_card = self
 
     def to_dict(self) -> dict:
         return {
@@ -32,11 +160,21 @@ class TarotCard:
             "name": self.name,
             "description": self.description,
             "cost": self.cost,
+            "targets": self.targets,
+            "action": self.action,
+            "params": self.params,
         }
 
     @classmethod
     def from_dict(cls, data: dict) -> "TarotCard":
-        return cls(data["name"], data["description"], data.get("cost", 0))
+        return cls(
+            data["name"],
+            data["description"],
+            data.get("cost", 0),
+            data.get("targets", 0),
+            data.get("action"),
+            data.get("params"),
+        )
 
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
@@ -50,10 +188,18 @@ def load_tarot_cards() -> list[TarotCard]:
 
     cards = []
     for entry in raw:
+        params = {
+            k: v
+            for k, v in entry.items()
+            if k not in {"name", "description", "targets", "action"}
+        }
         card = TarotCard(
             name=entry.get("name", ""),
             description=entry.get("description", ""),
             cost=3,
+            targets=int(entry.get("targets", 0)),
+            action=entry.get("action"),
+            params=params,
         )
         cards.append(card)
 

--- a/balatro/cli.py
+++ b/balatro/cli.py
@@ -78,6 +78,16 @@ class BalatroCLI:
                 self.game.discard_cards(card_indices)
             else:
                 print("Did you list the cards you want to discard after 'd'?")
+        elif action == "t":
+            if additional_input.strip().isdigit():
+                self.game.use_tarot_card(int(additional_input))
+            else:
+                print("Provide the index of the Tarot card to use.")
+        elif action == "s":
+            if additional_input.strip().isdigit():
+                self.game.use_spectral_card(int(additional_input))
+            else:
+                print("Provide the index of the Spectral card to use.")
         elif action == "c":
             self.game.show_deck()
         else:

--- a/balatro/core/game.py
+++ b/balatro/core/game.py
@@ -48,6 +48,7 @@ class Game:
         self.shop = Shop()
         self.round_earnings = 0
         self.voucher_purchased = False
+        self.last_used_card = None
         self.activate_vouchers()
 
     @property

--- a/balatro/core/player.py
+++ b/balatro/core/player.py
@@ -88,5 +88,6 @@ class Player:
         if 0 <= index < len(self.planet_cards):
             planet = self.planet_cards.pop(index)
             planet.apply_effect(game)
+            game.last_used_card = planet
         else:
             print("Invalid Planet card index.")

--- a/balatro/shop/shop.py
+++ b/balatro/shop/shop.py
@@ -61,34 +61,31 @@ class BoosterPack:
                 game.player.planet_cards.append(card)
                 print(f"Added {card.name} to your Planet Cards.")
             elif isinstance(card, TarotCard) or isinstance(card, SpectralCard):
-                # Display sample playing cards and current jokers for potential application
-                sample_cards = game.deck.cards[:8]
-                print("--- Available Cards for Application ---")
-                for i, c in enumerate(sample_cards):
-                    print(f"[{i}] {c}")
-                for j, joker in enumerate(game.player.jokers):
-                    print(f"[J{j}] {joker.name}")
-                print("---------------------------")
-                target = input("Select target index (number or J#) or press Enter to keep card: ").strip()
-                if target:
-                    if target.upper().startswith("J"):
+                hand_cards = game.player.hand
+                if card.targets > 0 and hand_cards:
+                    print("--- Available Cards for Application ---")
+                    for i, c in enumerate(hand_cards):
+                        print(f"[{i}] {c}")
+                    print("---------------------------")
+                    target = input(
+                        "Select target indices separated by space or press Enter to keep card: "
+                    ).strip()
+                    if target:
                         try:
-                            j_idx = int(target[1:])
-                            joker = game.player.jokers[j_idx]
-                            print(
-                                f"Applied {card.name} to {joker.name} (effect not yet implemented)."
-                            )
-                        except (ValueError, IndexError):
-                            print("Invalid joker selection.")
-                    else:
-                        try:
-                            c_idx = int(target)
-                            chosen_card = sample_cards[c_idx]
-                            print(
-                                f"Applied {card.name} to {chosen_card} (effect not yet implemented)."
-                            )
-                        except (ValueError, IndexError):
+                            indices = [int(x) for x in target.split()][: card.targets]
+                            chosen = [hand_cards[i] for i in indices if 0 <= i < len(hand_cards)]
+                            card.apply_effect(game, chosen)
+                        except ValueError:
                             print("Invalid card selection.")
+                        return
+                apply_now = False
+                if card.targets == 0:
+                    choice_apply = input(
+                        "Apply this card now? (y/n): "
+                    ).strip().lower()
+                    apply_now = choice_apply == "y"
+                if apply_now and card.targets == 0:
+                    card.apply_effect(game, [])
                 else:
                     if isinstance(card, TarotCard):
                         game.player.tarot_cards.append(card)

--- a/data/spectral_cards.json
+++ b/data/spectral_cards.json
@@ -1,74 +1,104 @@
 [
   {
     "name": "Familiar",
-    "effect": "Destroy 1 random card in your hand, but add 3 random Enhanced face cards instead."
+    "effect": "Destroy 1 random card in your hand, but add 3 random Enhanced face cards instead.",
+    "targets": 0
   },
   {
     "name": "Grim",
-    "effect": "Destroy 1 random card in your hand, but add 2 random Enhanced Aces instead."
+    "effect": "Destroy 1 random card in your hand, but add 2 random Enhanced Aces instead.",
+    "targets": 0
   },
   {
     "name": "Incantation",
-    "effect": "Destroy 1 random card in your hand, but add 4 random Enhanced numbered cards instead."
+    "effect": "Destroy 1 random card in your hand, but add 4 random Enhanced numbered cards instead.",
+    "targets": 0
   },
   {
     "name": "Talisman",
-    "effect": "Add a Gold Seal to 1 selected card."
+    "effect": "Add a Gold Seal to 1 selected card.",
+    "targets": 1,
+    "action": "add_seal",
+    "seal": "GOLD"
   },
   {
     "name": "Aura",
-    "effect": "Add Foil, Holographic, or Polychrome edition (determined at random) to 1 selected card in hand."
+    "effect": "Add Foil, Holographic, or Polychrome edition (determined at random) to 1 selected card in hand.",
+    "targets": 1,
+    "action": "add_random_edition"
   },
   {
     "name": "Wraith",
-    "effect": "Creates a random Rare Joker (must have room), but sets money to $0."
+    "effect": "Creates a random Rare Joker (must have room), but sets money to $0.",
+    "targets": 0
   },
   {
     "name": "Sigil",
-    "effect": "Converts all cards in hand to a single random suit."
+    "effect": "Converts all cards in hand to a single random suit.",
+    "targets": 0,
+    "action": "convert_all_random_suit"
   },
   {
     "name": "Ouija",
-    "effect": "Converts all cards in hand to a single random rank, but -1 Hand Size."
+    "effect": "Converts all cards in hand to a single random rank, but -1 Hand Size.",
+    "targets": 0
   },
   {
     "name": "Ectoplasm",
-    "effect": "Add Negative to a random Joker, but -1 Hand Size, plus another -1 hand size for each time Ectoplasm has been used this run, e.g. using Ectoplasm 3 times in the same run decreases hand size by a total of 6 (1+2+3)."
+    "effect": "Add Negative to a random Joker, but -1 Hand Size, plus another -1 hand size for each time Ectoplasm has been used this run, e.g. using Ectoplasm 3 times in the same run decreases hand size by a total of 6 (1+2+3).",
+    "targets": 0
   },
   {
     "name": "Immolate",
-    "effect": "Destroys 5 random cards in hand, but gain $20."
+    "effect": "Destroys 5 random cards in hand, but gain $20.",
+    "targets": 0
   },
   {
     "name": "Ankh",
-    "effect": "Creates a copy of 1 of your Jokers at random, then destroys the others, leaving you with two identical Jokers. (Editions are also copied, except Negative)."
+    "effect": "Creates a copy of 1 of your Jokers at random, then destroys the others, leaving you with two identical Jokers. (Editions are also copied, except Negative).",
+    "targets": 0
   },
   {
     "name": "Deja Vu",
-    "effect": "Adds a Red Seal to 1 selected card."
+    "effect": "Adds a Red Seal to 1 selected card.",
+    "targets": 1,
+    "action": "add_seal",
+    "seal": "RED"
   },
   {
     "name": "Hex",
-    "effect": "Adds Polychrome to a random Joker, and destroys the rest."
+    "effect": "Adds Polychrome to a random Joker, and destroys the rest.",
+    "targets": 0
   },
   {
     "name": "Trance",
-    "effect": "Adds a Blue Seal to 1 selected card."
+    "effect": "Adds a Blue Seal to 1 selected card.",
+    "targets": 1,
+    "action": "add_seal",
+    "seal": "BLUE"
   },
   {
     "name": "Medium",
-    "effect": "Adds a Purple Seal to 1 selected card."
+    "effect": "Adds a Purple Seal to 1 selected card.",
+    "targets": 1,
+    "action": "add_seal",
+    "seal": "PURPLE"
   },
   {
     "name": "Cryptid",
-    "effect": "Creates 2 exact copies (including Enhancements, Editions and Seals) of a selected card in your hand."
+    "effect": "Creates 2 exact copies (including Enhancements, Editions and Seals) of a selected card in your hand.",
+    "targets": 1,
+    "action": "copy_card",
+    "copies": 2
   },
   {
     "name": "The Soul",
-    "effect": "Creates a Legendary Joker. (Must have room)."
+    "effect": "Creates a Legendary Joker. (Must have room).",
+    "targets": 0
   },
   {
     "name": "Black Hole",
-    "effect": "Upgrades every poker hand (including secret hands not yet discovered) by one level."
+    "effect": "Upgrades every poker hand (including secret hands not yet discovered) by one level.",
+    "targets": 0
   }
 ]

--- a/data/tarot_cards.json
+++ b/data/tarot_cards.json
@@ -1,90 +1,147 @@
 [
   {
     "name": "The Fool (0)",
-    "description": "Creates a copy of the last Tarot or Planet card used. ( The Fool excluded)"
+    "description": "Creates a copy of the last Tarot or Planet card used. ( The Fool excluded)",
+    "targets": 0
   },
   {
     "name": "The Magician (I)",
-    "description": "Enhances 2 selected cards to Lucky Cards"
+    "description": "Enhances 2 selected cards to Lucky Cards",
+    "targets": 2,
+    "action": "apply_enhancement",
+    "enhancement": "LUCKY"
   },
   {
     "name": "The High Priestess (II)",
-    "description": "Creates up to 2 random Planet cards (Must have room)"
+    "description": "Creates up to 2 random Planet cards (Must have room)",
+    "targets": 0,
+    "action": "add_planet_cards",
+    "count": 2
   },
   {
     "name": "The Empress (III)",
-    "description": "Enhances 2 selected cards to Mult Cards"
+    "description": "Enhances 2 selected cards to Mult Cards",
+    "targets": 2,
+    "action": "apply_enhancement",
+    "enhancement": "MULT"
   },
   {
     "name": "The Emperor (IV)",
-    "description": "Creates up to 2 random Tarot cards (Must have room)"
+    "description": "Creates up to 2 random Tarot cards (Must have room)",
+    "targets": 0,
+    "action": "add_tarot_cards",
+    "count": 2
   },
   {
     "name": "The Hierophant (V)",
-    "description": "Enhances 2 selected cards to Bonus Cards"
+    "description": "Enhances 2 selected cards to Bonus Cards",
+    "targets": 2,
+    "action": "apply_enhancement",
+    "enhancement": "CHIP"
   },
   {
     "name": "The Lovers (VI)",
-    "description": "Enhances 1 selected card into a Wild Card"
+    "description": "Enhances 1 selected card into a Wild Card",
+    "targets": 1,
+    "action": "apply_enhancement",
+    "enhancement": "LUCKY"
   },
   {
     "name": "The Chariot (VII)",
-    "description": "Enhances 1 selected card into a Steel Card"
+    "description": "Enhances 1 selected card into a Steel Card",
+    "targets": 1,
+    "action": "apply_enhancement",
+    "enhancement": "STEEL"
   },
   {
     "name": "Justice (VIII)",
-    "description": "Enhances 1 selected card into a Glass Card"
+    "description": "Enhances 1 selected card into a Glass Card",
+    "targets": 1,
+    "action": "apply_enhancement",
+    "enhancement": "GLASS"
   },
   {
     "name": "The Hermit (IX)",
-    "description": "Doubles money (Max of $20 )"
+    "description": "Doubles money (Max of $20 )",
+    "targets": 0,
+    "action": "double_money"
   },
   {
     "name": "The Wheel of Fortune (X)",
-    "description": "1 in 4 chance to add Foil , Holographic , or Polychrome edition to a random Joker"
+    "description": "1 in 4 chance to add Foil , Holographic , or Polychrome edition to a random Joker",
+    "targets": 0,
+    "action": "wheel_of_fortune",
+    "chance": 0.25
   },
   {
     "name": "Strength (XI)",
-    "description": "Increases rank of up to 2 selected cards by 1 (Rank order: A→2→3→4→5→6→7→8→9→10→J→Q→K→A)"
+    "description": "Increases rank of up to 2 selected cards by 1 (Rank order: A→2→3→4→5→6→7→8→9→10→J→Q→K→A)",
+    "targets": 2,
+    "action": "increase_rank"
   },
   {
     "name": "The Hanged Man (XII)",
-    "description": "Destroys up to 2 selected cards"
+    "description": "Destroys up to 2 selected cards",
+    "targets": 2,
+    "action": "destroy"
   },
   {
     "name": "Death (XIII)",
-    "description": "Select 2 cards, convert the right card into the left card (Drag to rearrange)"
+    "description": "Select 2 cards, convert the right card into the left card (Drag to rearrange)",
+    "targets": 2,
+    "action": "transform"
   },
   {
     "name": "Temperance (XIV)",
-    "description": "Gives the total sell value of all current Jokers (Max of $50 )"
+    "description": "Gives the total sell value of all current Jokers (Max of $50 )",
+    "targets": 0
   },
   {
     "name": "The Devil (XV)",
-    "description": "Enhances 1 selected card into a Gold Card"
+    "description": "Enhances 1 selected card into a Gold Card",
+    "targets": 1,
+    "action": "apply_enhancement",
+    "enhancement": "GOLD"
   },
   {
     "name": "The Tower (XVI)",
-    "description": "Enhances 1 selected card into a Stone Card"
+    "description": "Enhances 1 selected card into a Stone Card",
+    "targets": 1,
+    "action": "apply_enhancement",
+    "enhancement": "STONE"
   },
   {
     "name": "The Star (XVII)",
-    "description": "Converts up to 3 selected cards to Diamonds"
+    "description": "Converts up to 3 selected cards to Diamonds",
+    "targets": 3,
+    "action": "convert_suit",
+    "suit": "DIAMONDS"
   },
   {
     "name": "The Moon (XVIII)",
-    "description": "Converts up to 3 selected cards to Clubs"
+    "description": "Converts up to 3 selected cards to Clubs",
+    "targets": 3,
+    "action": "convert_suit",
+    "suit": "CLUBS"
   },
   {
     "name": "The Sun (XIX)",
-    "description": "Converts up to 3 selected cards to Hearts"
+    "description": "Converts up to 3 selected cards to Hearts",
+    "targets": 3,
+    "action": "convert_suit",
+    "suit": "HEARTS"
   },
   {
     "name": "Judgement (XX)",
-    "description": "Creates a random Joker card (without in-run stickers ) (Must have room)"
+    "description": "Creates a random Joker card (without in-run stickers ) (Must have room)",
+    "targets": 0,
+    "action": "add_random_joker"
   },
   {
     "name": "The World (XXI)",
-    "description": "Converts up to 3 selected cards to Spades"
+    "description": "Converts up to 3 selected cards to Spades",
+    "targets": 3,
+    "action": "convert_suit",
+    "suit": "SPADES"
   }
 ]


### PR DESCRIPTION
## Summary
- add `t` and `s` CLI commands to play Tarot and Spectral cards from inventory
- support multi-target card application in booster packs and card data
- implement several Tarot and Spectral card effects and add Stone enhancement
- drive Tarot and Spectral card effects from JSON configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa65deba8883328f7dbe3b62d05022