### PR TITLE
Allow exiting from any prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Balatro CLI
 
-An attempt to have Gemini CLI recreate the game Balatro in the command line. 
+An attempt to have Gemini CLI recreate the game Balatro in the command line.
+
+Type `exit` at any prompt to quit the game instantly.
 
 
 # What I learned doing this project

--- a/TODO.md
+++ b/TODO.md
@@ -4,4 +4,4 @@
 [] implement any effect that is not implemented yet (search code base for "effect not implemented yet")
 [] Buying tarot/planet cards in the shop gives you the option to "apply now" or "put in hand"
 [] You can only have 2 consumables in your inventory unless expanded by a voucher/joker
-[] Give the user the option to exit at any point during gameplay
+[x] Give the user the option to exit at any point during gameplay

--- a/balatro/cards/spectral_cards.py
+++ b/balatro/cards/spectral_cards.py
@@ -7,6 +7,7 @@ import random
 from pathlib import Path
 
 from .cards import Card, Suit, Edition, Seal
+from ..utils import get_user_input
 
 
 class SpectralCard:
@@ -41,7 +42,7 @@ class SpectralCard:
             for i, c in enumerate(player.hand):
                 print(f"[{i}] {c}")
             print("---------------------------")
-            selection = input(
+            selection = get_user_input(
                 "Select target indices separated by space: "
             ).strip()
             if selection:

--- a/balatro/cards/tarot_cards.py
+++ b/balatro/cards/tarot_cards.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .cards import Card, Suit, Rank, Enhancement, Edition
 from ..cards.jokers import load_jokers
 from ..cards.planet_cards import load_planet_cards
+from ..utils import get_user_input
 
 
 class TarotCard:
@@ -43,7 +44,7 @@ class TarotCard:
             for i, c in enumerate(player.hand):
                 print(f"[{i}] {c}")
             print("---------------------------")
-            selection = input(
+            selection = get_user_input(
                 "Select target indices separated by space: "
             ).strip()
             if selection:

--- a/balatro/cli.py
+++ b/balatro/cli.py
@@ -12,6 +12,7 @@ extend or test in isolation.
 from typing import Optional
 
 from .core.game import Game, save_game, load_game
+from .utils import get_user_input
 
 
 class BalatroCLI:
@@ -37,6 +38,7 @@ class BalatroCLI:
         print("  'v': Save the current game.")
         print("  'l': Load a previously saved game.")
         print("  'q': Quit the game.")
+        print("  Type 'exit' at any prompt to quit immediately.")
         print("--------------------")
 
     def _handle_action(self, action: str, additional_input: Optional[str]) -> bool:
@@ -101,12 +103,12 @@ class BalatroCLI:
         while True:
             while not self.game.game_over:
                 print(self.game)
-                user_input = input("Enter your action: ").strip().lower()
+                user_input = get_user_input("Enter your action: ").strip().lower()
                 action = user_input[:1]
                 additional_input = user_input[1:]
                 if not self._handle_action(action, additional_input):
                     return self.game
-            again = input("Play again? (y/n): ").strip().lower()
+            again = get_user_input("Play again? (y/n): ").strip().lower()
             if again == "y":
                 deck_type = self.game.deck_key
                 self.game = Game(deck_type=deck_type)

--- a/balatro/core/game.py
+++ b/balatro/core/game.py
@@ -17,6 +17,7 @@ from ..cards.spectral_cards import spectral_card_from_dict
 from ..cards.planet_cards import planet_card_from_dict
 from ..shop.stickers import StickerType
 from .player import Player
+from ..utils import get_user_input
 
 
 class Game:
@@ -151,7 +152,7 @@ class Game:
         self.shop.generate_items(self)
         while True:
             self.shop.display_items(self.money)
-            choice = input(
+            choice = get_user_input(
                 "Select item to purchase or type 'leave' to continue: "
             ).strip().lower()
             if choice in ("", "leave", "l"):

--- a/balatro/shop/shop.py
+++ b/balatro/shop/shop.py
@@ -8,6 +8,7 @@ from .vouchers import Voucher, load_vouchers
 from ..cards.tarot_cards import TarotCard, load_tarot_cards
 from ..cards.spectral_cards import SpectralCard, load_spectral_cards
 from ..cards.planet_cards import PlanetCard, load_planet_cards
+from ..utils import get_user_input
 
 BASE_COSTS = {
     "Joker (Common)": 5,
@@ -48,7 +49,7 @@ class BoosterPack:
             desc = getattr(opt, "description", "")
             print(f"[{i}] {opt.name} - {desc}")
         print("---------------------------")
-        choice = input("Choose an item by index or press Enter to skip: ").strip()
+        choice = get_user_input("Choose an item by index or press Enter to skip: ").strip()
         if choice == "":
             return
         try:
@@ -70,7 +71,7 @@ class BoosterPack:
                     for i, c in enumerate(available_cards):
                         print(f"[{i}] {c}")
                     print("---------------------------")
-                    target = input(
+                    target = get_user_input(
                         "Select target indices separated by space or press Enter to keep card: "
                     ).strip()
                     if target:
@@ -87,7 +88,7 @@ class BoosterPack:
                         return
                 apply_now = False
                 if card.targets == 0:
-                    choice_apply = input(
+                    choice_apply = get_user_input(
                         "Apply this card now? (y/n): "
                     ).strip().lower()
                     apply_now = choice_apply == "y"

--- a/balatro/utils.py
+++ b/balatro/utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Utility helpers for the Balatro CLI project."""
+
+def get_user_input(prompt: str) -> str:
+    """Prompt the user for input and allow exiting the game.
+
+    If the user enters ``exit``, ``quit`` or ``q`` (case-insensitive),
+    a :class:`SystemExit` is raised so that the program terminates
+    gracefully.  Otherwise the raw input string is returned.
+    """
+    response = input(prompt)
+    if response.strip().lower() in {"exit", "quit", "q"}:
+        print("Exiting game.")
+        raise SystemExit
+    return response


### PR DESCRIPTION
## Summary
- centralize user input handling with `get_user_input` that exits on `exit`, `quit`, or `q`
- replace all direct `input()` calls with the new helper and document the behavior
- mark TODO item complete and note exit capability in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa58dd108332b53f202da9c9d3da