### PR TITLE
Show deck preview for tarot and spectral packs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # Balatro CLI Game Development Todo List
 
-[-] Spectral and Tarot packs show the 9 card hand available to apply card effect to
+[x] Spectral and Tarot packs show the 9 card hand available to apply card effect to
  - See cards when pack is opened, not just when card is chosen
- - Invalid selection closes pack. See "testing_results/issue_1.md"
+ - Invalid selection no longer closes pack. See "testing_results/issue_1.md"
 [x] implement any effect that is not yet implemented (search code base for "effect not yet implemented")
 [x] Buying tarot/planet cards in the shop gives you the option to "apply now" or "put in hand"
 [x] You can only have 2 consumables in your inventory unless expanded by a voucher/joker


### PR DESCRIPTION
## Summary
- Display up to nine random cards from the deck when opening tarot or spectral booster packs.
- Keep booster packs open on invalid target input by re-prompting until a valid selection is made.
- Update TODO to reflect completed booster pack improvements.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b3809ec4833298806d2e3031cb45