### PR TITLE
Implement Riff-Raff joker and spectral card application

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 [x] Buying tarot/planet cards in the shop gives you the option to "apply now" or "put in hand"
 [x] You can only have 2 consumables in your inventory unless expanded by a voucher/joker
 [x] Give the user the option to exit at any point during gameplay
-[ ] Only cards in the hand played count in scoring (example: if user plays pair, only the cards in the pair count in scoring). 
+[ ] Only cards in the hand played count in scoring (example: if user plays pair, only the cards in the pair count in scoring).
  - This can be reversed by an effect. (See Joker "Splash" as an example)
-[ ] Bug: Tarot/Spectral cards that apply an effect to a playing card bought in shop outside of a card pack, can only be put into consumable slot inventory. Do not show playing cards available to apply to. See "testing_results/issue_2.md"
-[ ] Bug: Riff-Raff Joker does not work. When blind is selected it doesn't create two common jokers. See "testing_results/issue_3.md"
+[x] Bug: Tarot/Spectral cards that apply an effect to a playing card bought in shop outside of a card pack now show playing cards available to apply to. See "testing_results/issue_2.md"
+[x] Bug: Riff-Raff Joker now creates two common jokers when a blind is selected. See "testing_results/issue_3.md"

--- a/balatro/core/game.py
+++ b/balatro/core/game.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 """Game engine and orchestration logic."""
 
 import json
+import random
 
 from .deck import BaseDeck, RedDeck, GreenDeck, YellowDeck
 from ..cards.cards import Card
 from .poker import evaluate_hand
 from .scoring import calculate_score
-from ..cards.jokers import joker_from_dict
+from ..cards.jokers import joker_from_dict, load_jokers
 from ..shop.vouchers import voucher_from_dict
 from .blinds import BlindManager
 from ..shop.shop import Shop
@@ -142,6 +143,20 @@ class Game:
         print(
             f"\n--- Advancing to {self.blind_manager.current.name} (Score required: {self.blind_manager.current.score_required}) ---"
         )
+        # Riff-Raff Joker effect
+        for joker in self.player.jokers:
+            if joker.name == "Riff-Raff":
+                commons = [j for j in load_jokers() if getattr(j, "rarity", "").lower() == "common"]
+                slots = max(0, 5 - len(self.player.jokers))
+                to_create = min(2, slots)
+                if to_create <= 0:
+                    print("No room for Riff-Raff to create Jokers.")
+                    break
+                for _ in range(to_create):
+                    self.player.jokers.append(random.choice(commons))
+                plural = "s" if to_create > 1 else ""
+                print(f"Riff-Raff created {to_create} Common Joker{plural}.")
+                break
 
     def end_of_round_winnings(self) -> int:
         base = 10

--- a/balatro/shop/shop.py
+++ b/balatro/shop/shop.py
@@ -243,10 +243,49 @@ class Shop:
                         else:
                             print(f"Purchased {item.name}! Added to your Tarot Cards.")
                 elif isinstance(item, SpectralCard):
-                    if not game.player.add_spectral_card(item):
-                        print(f"Purchased {item.name}, but no room to store it.")
+                    if item.targets > 0:
+                        deck_cards = game.player.deck.cards
+                        available_cards = (
+                            random.sample(deck_cards, min(9, len(deck_cards))) if deck_cards else []
+                        )
+                        if available_cards:
+                            print("--- 9 Card Hand ---")
+                            for i, c in enumerate(available_cards):
+                                print(f"[{i}] {c}")
+                            print("-------------------")
+                            target = get_user_input(
+                                "Select target indices separated by space or press Enter to keep card: "
+                            ).strip()
+                            if target:
+                                try:
+                                    indices = [int(x) for x in target.split()][: item.targets]
+                                    chosen = [
+                                        available_cards[i]
+                                        for i in indices
+                                        if 0 <= i < len(available_cards)
+                                    ]
+                                    if len(chosen) != len(indices):
+                                        raise ValueError
+                                    item.apply_effect(game, chosen)
+                                    self.items.pop(item_index)
+                                    return True
+                                except ValueError:
+                                    print("Invalid card selection.")
+                    apply_now = False
+                    if item.targets == 0:
+                        apply_now = (
+                            get_user_input("Apply this card now? (y/n): ")
+                            .strip()
+                            .lower()
+                            == "y"
+                        )
+                    if apply_now and item.targets == 0:
+                        item.apply_effect(game, [])
                     else:
-                        print(f"Purchased {item.name}! Added to your Spectral Cards.")
+                        if not game.player.add_spectral_card(item):
+                            print(f"Purchased {item.name}, but no room to store it.")
+                        else:
+                            print(f"Purchased {item.name}! Added to your Spectral Cards.")
                 elif isinstance(item, PlanetCard):
                     apply_now = (
                         get_user_input("Apply this card now? (y/n): ")


### PR DESCRIPTION
## Summary
- Add Riff-Raff Joker effect spawning up to two random Common Jokers when a blind is selected
- Allow applying spectral cards to selected deck cards when purchasing from the shop
- Update TODO list to reflect bug fixes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b87389688332841ff6c4aa87d851