### PR TITLE
Implement immolate card fix and rarity weighting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,6 @@
 [x] Bug: Tarot/Spectral cards that apply an effect to a playing card bought in shop outside of a card pack now show playing cards available to apply to. See "testing_results/issue_2.md"
 [x] Bug: Riff-Raff Joker now creates two common jokers when a blind is selected. See "testing_results/issue_3.md"
 [x] Implement interest. See "data/interest.md" 
-[ ] Bug: Imolate Spectral card only destroys 3 cards. See "testing_results/issue_4.md"
+[x] Bug: Imolate Spectral card only destroys 3 cards. See "testing_results/issue_4.md"
  - Show user which cards are destroyed
-[ ] Rarity of item influences the chance of them showing up in shop/packs
+[x] Rarity of item influences the chance of them showing up in shop/packs

--- a/balatro/cards/spectral_cards.py
+++ b/balatro/cards/spectral_cards.py
@@ -147,11 +147,16 @@ class SpectralCard:
             print(f"Hand size reduced to {game.player.hand_size}.")
 
         def _immolate(game, _selected, _params):
+            if not game.player.hand:
+                print("No cards to destroy.")
+                return
             count = min(5, len(game.player.hand))
-            for _ in range(count):
-                game.player.hand.pop(random.randrange(len(game.player.hand)))
+            indices = random.sample(range(len(game.player.hand)), count)
+            indices.sort(reverse=True)
+            destroyed = [game.player.hand.pop(i) for i in indices]
             game.money += 20
-            print(f"Destroyed {count} cards and gained $20.")
+            destroyed_str = ", ".join(str(c) for c in destroyed)
+            print(f"Destroyed {count} cards ({destroyed_str}) and gained $20.")
 
         def _ankh(game, _selected, _params):
             if not game.player.jokers:

--- a/balatro/shop/shop.py
+++ b/balatro/shop/shop.py
@@ -22,6 +22,26 @@ BASE_COSTS = {
     "Voucher": 10,
 }
 
+RARITY_WEIGHTS = {
+    "common": 60,
+    "uncommon": 30,
+    "rare": 9,
+    "legendary": 1,
+}
+
+
+def weighted_sample(items, k):
+    temp_items = list(items)
+    weights = [RARITY_WEIGHTS.get(getattr(it, "rarity", "").lower(), 1) for it in temp_items]
+    selected = []
+    for _ in range(min(k, len(temp_items))):
+        choice = random.choices(temp_items, weights=weights, k=1)[0]
+        idx = temp_items.index(choice)
+        selected.append(choice)
+        temp_items.pop(idx)
+        weights.pop(idx)
+    return selected
+
 
 class BoosterPack:
     """Simple representation of a booster pack."""
@@ -37,7 +57,7 @@ class BoosterPack:
         """Generate cards based on pack type and let the player pick one."""
         available_cards = []
         if self.pack_type == "joker":
-            options = random.sample(load_jokers(), 3)
+            options = weighted_sample(load_jokers(), 3)
         elif self.pack_type == "tarot":
             options = random.sample(load_tarot_cards(), 3)
             deck_cards = game.player.deck.cards
@@ -164,7 +184,7 @@ class Shop:
         for _ in range(2):
             choice = random.choice(["joker", "tarot", "planet"])
             if choice == "joker":
-                item = random.choice(load_jokers())
+                item = weighted_sample(load_jokers(), 1)[0]
             elif choice == "tarot":
                 item = random.choice(load_tarot_cards())
                 item.cost = BASE_COSTS["Tarot Card"]


### PR DESCRIPTION
## Summary
- Ensure Immolate destroys up to five cards and shows the cards removed
- Weight joker appearances in shop and booster packs by item rarity
- Mark related tasks as complete in TODO

## Testing
- `python -m py_compile balatro/cards/spectral_cards.py balatro/shop/shop.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5d72c90f483329e25b0e241b76b1d