### PR TITLE
Return played cards to deck

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,5 +17,5 @@
 [x] Rarity of item influences the chance of them showing up in shop/packs
 [ ] Implement Selling Consumable items and Jokers. (sell_cost = math.max(1, math.floor(cost/2)) + ability_extra_value) | ability extra value  (+2 if foil, +3 if holo, +5 if polychrome, +5 if negative)
  - Swashbucker card seems to be only using the number of jokers to the multiplier
-[ ] Bug: Arcana pack is only showing 4 cards after purchase in the shop. I believe this is due to cards played previously are not being put back in deck. See "testing_results/issue_5.md"
-[ ] Bug: Buying a pack should generate a new random set of 9 cards instead of keeping the same set in round. Could be a result of cards not being put back in deck. See "testing_results/issue_6.md"
+[x] Bug: Arcana pack is only showing 4 cards after purchase in the shop. I believe this is due to cards played previously are not being put back in deck. See "testing_results/issue_5.md"
+[x] Bug: Buying a pack should generate a new random set of 9 cards instead of keeping the same set in round. Could be a result of cards not being put back in deck. See "testing_results/issue_6.md"

--- a/balatro/core/deck.py
+++ b/balatro/core/deck.py
@@ -34,9 +34,16 @@ class BaseDeck:
             drawn_cards = self.cards[:]
             self.cards = []
             return drawn_cards
-        
+
         drawn_cards = [self.cards.pop() for _ in range(num_cards)]
         return drawn_cards
+
+    def return_cards(self, cards: list[Card]) -> None:
+        """Return cards to the deck and reshuffle."""
+        if not cards:
+            return
+        self.cards.extend(cards)
+        self.shuffle()
 
 class RedDeck(BaseDeck):
     """Represents the Red Deck, which provides an extra discard every round."""

--- a/balatro/core/game.py
+++ b/balatro/core/game.py
@@ -260,6 +260,7 @@ class Game:
             print("Error: One or more cards are not in the current hand.")
             return
 
+        played_cards = list(cards_to_play)
         for card in cards_to_play:
             self.player.hand.remove(card)
 
@@ -282,6 +283,7 @@ class Game:
         else:
             print("No valid poker hand was played.")
 
+        self.deck.return_cards(played_cards)
         self.player.hands -= 1
         print(
             f"Played {len(cards_to_play)} cards. {self.player.hands} hands remaining."

--- a/balatro/core/player.py
+++ b/balatro/core/player.py
@@ -48,6 +48,8 @@ class Player:
         self.hand.sort(key=card_sort_key)
 
     def draw_hand(self) -> None:
+        if self.hand:
+            self.deck.return_cards(self.hand)
         self.hand = self.deck.draw(self.hand_size)
         self.sort_hand()
 
@@ -66,6 +68,7 @@ class Player:
         for index in card_indices:
             discarded.append(self.hand.pop(index))
         self.discards -= 1
+        self.deck.return_cards(discarded)
         new_cards = self.deck.draw(len(discarded))
         self.hand.extend(new_cards)
         self.sort_hand()


### PR DESCRIPTION
## Summary
- ensure deck cards are returned after plays and discards
- shuffle returned cards into deck and reset hands each round
- mark arcana pack and booster pack bugs resolved in TODO

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from balatro.core.game import Game

g = Game()
g.draw_hand()
print('deck after draw:', len(g.deck.cards))
cards_to_play = g.player.hand[:5]
g.play_hand(cards_to_play)
print('deck after play:', len(g.deck.cards))
g.discard_cards([0,1])
print('deck after discard:', len(g.deck.cards))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5f380d6708332a3bb29b6967a7184